### PR TITLE
Add the new CPU committee to the allowed groups

### DIFF
--- a/gasta/src/lib/server/auth.ts
+++ b/gasta/src/lib/server/auth.ts
@@ -112,7 +112,7 @@ export type Authenticate =
 	  };
 
 // (|(*group logic*)(*another group logic*))
-const filter = `(|${['dsek.km', 'dsek.cafe', 'dsek.sex']
+const filter = `(|${['dsek.km', 'dsek.cafe', 'dsek.sex', 'dsek.cpu']
 	.map((g) => `(memberOf=cn=${g},cn=groups,cn=accounts,dc=dsek,dc=se)`)
 	.join('')})`;
 


### PR DESCRIPTION
With the new committee being active and running our servers, we should probably allow them to edit the schedules of our displays.